### PR TITLE
[fix] 자동 연동 설정 조회 시 조건이 없는 상태에서도 비활성화만 조회되는 오류

### DIFF
--- a/src/main/java/org/codeiteam3/findex/autosyncconfig/controller/AutoSyncConfigController.java
+++ b/src/main/java/org/codeiteam3/findex/autosyncconfig/controller/AutoSyncConfigController.java
@@ -28,7 +28,7 @@ public class AutoSyncConfigController {
     @GetMapping
     public ResponseEntity<CursorPageResponse<AutoSyncConfigResponseDto>> findAll(
         @RequestParam(required = false) UUID indexInfoId,
-        @RequestParam(required = false) boolean enabled,
+        @RequestParam(required = false) Boolean enabled,
         @RequestParam(required = false) UUID idAfter,
         @RequestParam(required = false) String cursor,
         @RequestParam(required = false, defaultValue = "indexInfo.indexName") String sortField,

--- a/src/main/java/org/codeiteam3/findex/autosyncconfig/entity/AutoSyncConfig.java
+++ b/src/main/java/org/codeiteam3/findex/autosyncconfig/entity/AutoSyncConfig.java
@@ -1,4 +1,4 @@
-package org.codeiteam3.findex.autosyncconfig;
+package org.codeiteam3.findex.autosyncconfig.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/src/main/java/org/codeiteam3/findex/autosyncconfig/mapper/AutoSyncConfigMapper.java
+++ b/src/main/java/org/codeiteam3/findex/autosyncconfig/mapper/AutoSyncConfigMapper.java
@@ -1,6 +1,6 @@
 package org.codeiteam3.findex.autosyncconfig.mapper;
 
-import org.codeiteam3.findex.autosyncconfig.AutoSyncConfig;
+import org.codeiteam3.findex.autosyncconfig.entity.AutoSyncConfig;
 import org.codeiteam3.findex.autosyncconfig.dto.AutoSyncConfigResponseDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;

--- a/src/main/java/org/codeiteam3/findex/autosyncconfig/repository/AutoSyncConfigRepository.java
+++ b/src/main/java/org/codeiteam3/findex/autosyncconfig/repository/AutoSyncConfigRepository.java
@@ -1,6 +1,6 @@
 package org.codeiteam3.findex.autosyncconfig.repository;
 
-import org.codeiteam3.findex.autosyncconfig.AutoSyncConfig;
+import org.codeiteam3.findex.autosyncconfig.entity.AutoSyncConfig;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/org/codeiteam3/findex/autosyncconfig/service/AutoSyncConfigService.java
+++ b/src/main/java/org/codeiteam3/findex/autosyncconfig/service/AutoSyncConfigService.java
@@ -1,7 +1,7 @@
 package org.codeiteam3.findex.autosyncconfig.service;
 
 import lombok.RequiredArgsConstructor;
-import org.codeiteam3.findex.autosyncconfig.AutoSyncConfig;
+import org.codeiteam3.findex.autosyncconfig.entity.AutoSyncConfig;
 import org.codeiteam3.findex.autosyncconfig.dto.AutoSyncConfigResponseDto;
 import org.codeiteam3.findex.autosyncconfig.dto.AutoSyncConfigUpdateRequestDto;
 import org.codeiteam3.findex.autosyncconfig.mapper.AutoSyncConfigMapper;
@@ -39,7 +39,7 @@ public class AutoSyncConfigService {
     @Transactional(readOnly = true)
     public CursorPageResponse<AutoSyncConfigResponseDto> findAll(
             UUID indexInfoId,
-            boolean enabled,
+            Boolean enabled,
             UUID idAfter,
             String cursor,
             String sortField,
@@ -118,18 +118,20 @@ public class AutoSyncConfigService {
             Pageable pageable
     ){
 
-        return switch (sortField){
-
-            case "indexInfo.indexName" -> {
-
-                yield cursor == null
-                        ? autoSyncConfigRepository.findAllByIndexInfoFirstPage(indexInfoId, enabled, pageable)
-                        : direction.isDescending()
-                        ? autoSyncConfigRepository.findAllByIndexInfoNextPageDesc(indexInfoId, enabled, idAfter, cursor, pageable)
-                        : autoSyncConfigRepository.findAllByIndexInfoNextPageAsc(indexInfoId, enabled, idAfter, cursor, pageable);
-            }
-            default -> throw new IllegalArgumentException("제대로 되지 않은 sortField 입니다.");
-        };
+        if (cursor == null) {
+            return autoSyncConfigRepository.findAllByIndexInfoFirstPage(
+                    indexInfoId, enabled, pageable
+            );
+        }
+        if (direction.isDescending()) {
+            return autoSyncConfigRepository.findAllByIndexInfoNextPageDesc(
+                    indexInfoId, enabled, idAfter, cursor, pageable
+            );
+        } else {
+            return autoSyncConfigRepository.findAllByIndexInfoNextPageAsc(
+                    indexInfoId, enabled, idAfter, cursor, pageable
+            );
+        }
     }
 
 

--- a/src/main/java/org/codeiteam3/findex/indexinfo/service/IndexInfoService.java
+++ b/src/main/java/org/codeiteam3/findex/indexinfo/service/IndexInfoService.java
@@ -1,7 +1,7 @@
 package org.codeiteam3.findex.indexinfo.service;
 
 import lombok.RequiredArgsConstructor;
-import org.codeiteam3.findex.autosyncconfig.AutoSyncConfig;
+import org.codeiteam3.findex.autosyncconfig.entity.AutoSyncConfig;
 import org.codeiteam3.findex.autosyncconfig.repository.AutoSyncConfigRepository;
 import org.codeiteam3.findex.pagination.CursorPageResponse;
 import org.codeiteam3.findex.pagination.CursorPageResponseMapper;

--- a/src/main/java/org/codeiteam3/findex/syncjob/service/SyncJobService.java
+++ b/src/main/java/org/codeiteam3/findex/syncjob/service/SyncJobService.java
@@ -1,7 +1,7 @@
 package org.codeiteam3.findex.syncjob.service;
 
 import lombok.RequiredArgsConstructor;
-import org.codeiteam3.findex.autosyncconfig.AutoSyncConfig;
+import org.codeiteam3.findex.autosyncconfig.entity.AutoSyncConfig;
 import org.codeiteam3.findex.autosyncconfig.repository.AutoSyncConfigRepository;
 import org.codeiteam3.findex.pagination.CursorPageResponse;
 import org.codeiteam3.findex.pagination.CursorPageResponseMapper;


### PR DESCRIPTION
## #️⃣연관된 이슈

Closes #136 

## 📝작업 내용

> 자동 연동 설정 조회 시 조건이 없는 상태에서도 비활성화만 조회되는 오류를 수정하였으며, 그 과정에서 AutoSyncConfig 엔티티의 패키지 위치가 잘못 설정되어 있어 그 부분도 수정하였고, 정상 작동됨을 확인하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요