### PR TITLE
fix: IndexInfo 객체 수정/생성 시 기준 시점 값을 basDt에서 basPntm 값으로 변경

### DIFF
--- a/src/main/java/org/codeiteam3/findex/syncjob/service/SyncJobService.java
+++ b/src/main/java/org/codeiteam3/findex/syncjob/service/SyncJobService.java
@@ -134,7 +134,7 @@ public class SyncJobService {
             if(indexInfo != null){
                 indexInfo.update(
                         Integer.parseInt(item.epyItmsCnt()),
-                        LocalDate.parse(item.basDt(), DateTimeFormatter.ofPattern("yyyyMMdd")),
+                        LocalDate.parse(item.basPntm(), DateTimeFormatter.ofPattern("yyyyMMdd")),
                         new BigDecimal(item.basIdx()),
                         null
                 );
@@ -148,7 +148,7 @@ public class SyncJobService {
                         item.idxCsf(),
                         item.idxNm(),
                         Integer.parseInt(item.epyItmsCnt()),
-                        LocalDate.parse(item.basDt(), DateTimeFormatter.ofPattern("yyyyMMdd")),
+                        LocalDate.parse(item.basPntm(), DateTimeFormatter.ofPattern("yyyyMMdd")),
                         new BigDecimal(item.basIdx()),
                         OPEN_API,
                         false
@@ -163,7 +163,7 @@ public class SyncJobService {
                     item.idxCsf(),
                     item.idxNm(),
                     Integer.parseInt(item.epyItmsCnt()),
-                    LocalDate.parse(item.basDt(), DateTimeFormatter.ofPattern("yyyyMMdd")),
+                    LocalDate.parse(item.basPntm(), DateTimeFormatter.ofPattern("yyyyMMdd")),
                     new BigDecimal(item.basIdx()),
                     OPEN_API,
                     false


### PR DESCRIPTION
## #️⃣연관된 이슈

Closes #143 

## 📝작업 내용

> api 연동을 통해 데이터를 가져올 때 기준 시점 값 위치에 기준 일자값이 들어가는 버그를 발견하여 IndexInfo 객체 수정/생성 시 '기준 시점' 값을 basDt에서 basPntm 값으로 변경

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요